### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can run the migration scripts from any Node.js environment, such as from you
 2. Download or clone this repository.
 
     ```sh
-    git clone https://github.ibm.com/security-services/secrets-manager-cm-migration-scripts.git
+    git clone https://github.com/ibm-cloud-security/certificate-manager-to-secrets-manager.git
     ```
 
 3. In your project directory, install required packages using `npm`.


### PR DESCRIPTION
This PR updates the README to fix the git repo URL. Addresses https://github.com/ibm-cloud-security/certificate-manager-to-secrets-manager/issues/4.