### PR TITLE
fix: Support for certificates starting with asterisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Use this script to copy a single certificate from a Certificate Manager instance
 Keep in mind the following limitations:
 
 * Secrets Manager does not support secret names with spaces. If the name of the requested certificate contains spaces, the script will replace those spaces with dashes (`-`).
+* Secrets Manager does not support secret names that start with *. If the name of the requested certificate starts with *, the script will replace that with 'star'.
 * This script can't be run against instances that are accessible only through private service endpoints. 
 
 #### Instructions
@@ -211,6 +212,7 @@ Use this script to copy all of the imported certificates that are managed in a C
 Keep in mind the following limitations:
 
 * Secrets Manager does not support secret names with spaces. If the name of the requested certificate contains spaces, the script will replace those spaces with dashes (`-`).
+* Secrets Manager does not support secret names that start with *. If the name of the requested certificate starts with *, the script will replace that with 'star'.
 * This script can't be run against instances that are accessible only through private service endpoints. 
 
 #### Instructions
@@ -291,6 +293,7 @@ Use this script to order a single public certificate in a destination Secrets Ma
 Keep in mind the following limitations:
 
 * Secrets Manager does not support secret names with spaces. If the name of the requested certificate contains spaces, the script will replace those spaces with dashes (`-`).
+* Secrets Manager does not support secret names that start with *. If the name of the requested certificate starts with *, the script will replace that with 'star'.
 * This script can't be run against instances that are accessible only through private service endpoints. 
 
 #### Instructions
@@ -382,6 +385,7 @@ Use this script to order all public certificates in a destination Secrets Manage
 Keep in mind the following limitations:
 
 * Secrets Manager does not support secret names with spaces. If the name of the requested certificate contains spaces, the script will replace those spaces with dashes (`-`).
+* Secrets Manager does not support secret names that start with *. If the name of the requested certificate starts with *, the script will replace that with 'star'.
 * This script can't be run against instances that are accessible only through private service endpoints. 
 
 #### Instructions

--- a/cm_migration.js
+++ b/cm_migration.js
@@ -575,13 +575,17 @@ async function get_notification_number(location, crn_enc, cm_api_prefix, token){
 /////////// cm_cert_copy functions ///////////
 
 async function add_cert_to_secret(sm_crn, sm_instance_id, secret_group_name, cert_data, sm_location, sm_token, sm_api_prefix, only_imported){
-    const name = cert_data.name;
+    let name = cert_data.name;
     const description = cert_data.description;
     const private_key = cert_data.data.priv_key;
     const intermediate = cert_data.data.intermediate;
     const certificate_content = cert_data.data.content;
     const is_imported = cert_data.imported;
     let secret_group_id = secret_group_name;
+
+    if(name.charAt(0) === '*'){
+        name="star"+name.substring(1);
+    }
 
     if(!is_imported && only_imported){
         return false;


### PR DESCRIPTION
Fix suggested by Jerome Lanneluc: https://ibm-cloudplatform.slack.com/archives/C010Z1DQ05N/p1666705814497569?thread_ts=1666704434.448609&cid=C010Z1DQ05N